### PR TITLE
Fix display bug and add alive cells and generation number to status line

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,31 @@ This command line tool simulates Conway's Game of Life in 2D.
     2. If the score is 4, then the cell will live if it is live in the current generation
     3. Otherwise the cell will be dead
 
+### Computational complexity
+
+The time complexity for generating a new state is linear with the alive cells.
+The idea is that if we have N alive cells, then we roughly have 9*N considered cells.
+Computing the score for these cells takes 9*9*N steps.
+If we consider the set operations to work in constant/O(1) time, then we roughly have 81*N operations.
+That means that the complexity is O(n) amortized, in some cases O(n^2) if set/hash operations take linear time, but that should be rare for small N-s.
+It is also linear, because we are taking only the alive cells, not the whole universe.
+
+The space complexity should also be O(n) because we are working with two sets, one for the current alive cells, and one for the considered sets for the next generation.
+It could also be O(n^2) when creating the new set of alive cells, but it is not as Elixir handles these copies with persistent data structures.
+
 ## Building and running
+
+### Config
+
+We have the following properties to configure:
+    
+   * Tick - the waiting time before generating the new universe
+        
+        `config :game_of_life, tick: 500`
+
+   * Display limit - the maximum number of rows and cells to display
+        
+        `config :game_of_life, display_limit: 50`
 
 ### Build
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,4 +2,7 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
+# Tick is the waiting time before generating the new universe
 config :game_of_life, tick: 500
+# Display limit is the maximum number of rows and cells to display
+config :game_of_life, display_limit: 30

--- a/lib/game_of_life/game_controller.ex
+++ b/lib/game_of_life/game_controller.ex
@@ -20,7 +20,6 @@ defmodule GameOfLife.GameController do
     receive do
       :tick ->
         handle_tick(live_cells)
-
       {:state, pid} ->
         handle_send_state(live_cells, pid)
     end

--- a/lib/game_of_life/helpers/math_common.ex
+++ b/lib/game_of_life/helpers/math_common.ex
@@ -4,13 +4,17 @@ defmodule GameOfLife.Helpers.MathCommon do
   # It gets a dimension size, and returns the bounds of the universe according to the specifications
   @spec compute_universe_bounds(pos_integer()) :: Universe.bounds()
   def compute_universe_bounds(dimension_size) do
-    size = trunc(dimension_size / 2)
-
+    size = trunc((dimension_size - 1) / 2)
     if rem(dimension_size, 2) === 0 do
-      {-size, -size, size - 1, size - 1}
+      {-size - 1, -size - 1, size, size}
     else
       {-size, -size, size, size}
     end
+  end
+
+  @spec bounds_to_dimension_size(Universe.bounds()) :: pos_integer()
+  def bounds_to_dimension_size({lower_bound, _, upper_bound, _}) do
+    abs(lower_bound) + upper_bound + 1
   end
 
   @doc """

--- a/lib/game_of_life/ui.ex
+++ b/lib/game_of_life/ui.ex
@@ -6,13 +6,23 @@ defmodule GameOfLife.UI do
 
   @process :ui
   @controls "Controls: (c)ontinue, (p)ause, (s)ave, change spee(d), (e)xit"
+  @status_agent :status_agent
 
   def start(initial_state) do
+    initialize_alive_cells_agent(initial_state)
     Process.register(self(), @process)
     GC.start(initial_state)
     SC.start()
     IC.start()
     loop()
+  end
+
+  def initialize_alive_cells_agent(initial_state) do
+    alive_cells_nr = Enum.count(initial_state)
+    Agent.start_link fn ->
+      Process.register(self(), @status_agent)
+      {1, alive_cells_nr}
+    end
   end
 
   # Server
@@ -26,7 +36,7 @@ defmodule GameOfLife.UI do
     end
   end
 
-  defp wait_for_game_controller() do
+  defp wait_for_notify() do
     receive do
       :continue -> loop()
       :exit -> :ok
@@ -36,30 +46,35 @@ defmodule GameOfLife.UI do
   defp on_user_input(letter) do
     case get_state(letter) do
       nil ->
-        IO.puts("Control #{letter} is not recognized")
+        print("Control #{letter} is not recognized")
         IC.continue()
         loop()
 
       state ->
         SC.new_game_state(state)
-        wait_for_game_controller()
+        wait_for_notify()
     end
   end
 
   defp on_game_output(output) do
-    if Enum.count(output) === 0 do
-      IO.puts("All cells have died")
+    alive_cells_nr = Enum.count(output)
+    update_alive_cells_nr_and_increment_gen_nr(alive_cells_nr)
+    if alive_cells_nr === 0 do
+      print("All cells have died")
     else
       output
       |> Displayer.build()
-      |> IO.puts()
+      |> print
 
       loop()
     end
   end
 
+  @spec print_controls() :: any()
   defp print_controls() do
-    IO.puts("#{DateTime.utc_now()}  #{@controls}")
+    {gen_nr, alive_cells_nr} = get_alive_cells_and_generation_nr()
+    print("#{DateTime.utc_now()} Generation ##{gen_nr} Alive cells: #{alive_cells_nr}")
+    print("#{@controls}")
   end
 
   @spec get_state(String.t()) :: SC.state() | nil
@@ -72,6 +87,13 @@ defmodule GameOfLife.UI do
       "d" -> :speed
       _ -> nil
     end
+  end
+
+  @spec get_alive_cells_and_generation_nr :: {non_neg_integer(), pos_integer()}
+  def get_alive_cells_and_generation_nr(), do: Agent.get(@status_agent, fn numbers -> numbers end)
+  @spec update_alive_cells_nr_and_increment_gen_nr(non_neg_integer()) :: any()
+  def update_alive_cells_nr_and_increment_gen_nr(alive_cells_nr) do
+    Agent.update(@status_agent, fn {gen_nr, _} -> {gen_nr + 1, alive_cells_nr} end)
   end
 
   # Client

--- a/test/math_common_test.exs
+++ b/test/math_common_test.exs
@@ -19,4 +19,12 @@ defmodule MathCommonTest do
     assert compute_universe_bounds(5) === {-2, -2, 2, 2}
     assert compute_universe_bounds(10) === {-5, -5, 4, 4}
   end
+
+  test "bounds_to_dimension_size" do
+    assert bounds_to_dimension_size({0, 0, 3, 0}) === 4
+    assert bounds_to_dimension_size({0, 200, 3, 300}) === 4
+    assert bounds_to_dimension_size({-2, nil, 2, nil}) === 5
+    assert bounds_to_dimension_size({-5, 0, 4, 0}) === 10
+    assert bounds_to_dimension_size({0, 0, 0, 0}) === 1
+  end
 end


### PR DESCRIPTION
Fixes #1 
Fix display bug for big universes, the column and row number would show more than the dimension size
Add alive cells and generation number to the status line
Make display limit configurable
Add documentation for computational complexity and config parameters