### PR TITLE
Fix display bug, support big universe with many alive cells far from each other

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -3,6 +3,6 @@
 use Mix.Config
 
 # Tick is the waiting time before generating the new universe
-config :game_of_life, tick: 500
+config :game_of_life, tick: 200
 # Display limit is the maximum number of rows and cells to display
-config :game_of_life, display_limit: 30
+config :game_of_life, display_limit: 35


### PR DESCRIPTION
Fix display bug, where the calculation would result in the whole universe
Support big universes with many alive cells that are far from each other, in this case the center of the universe will be displayed